### PR TITLE
Set interface numbers to 80000 for healbot and tooltips

### DIFF
--- a/HealBot/HealBot.toc
+++ b/HealBot/HealBot.toc
@@ -1,4 +1,4 @@
-## Interface: 80100
+## Interface: 80000
 ## Title: HealBot
 ## Author: Strife
 ## Notes: Adds a panel with skinable bars for healing, decursive, buffing, ressing, range checking and aggro tracking

--- a/HealBot_Tips/HealBot_Tips.toc
+++ b/HealBot_Tips/HealBot_Tips.toc
@@ -1,4 +1,4 @@
-## Interface: 70300
+## Interface: 80000
 ## Title: HealBot Tooltips
 ## Author: Strife
 ## Notes: HealBot Tooltips, only loads if Tooltips are used


### PR DESCRIPTION
This fixes the interface numbers for the main healbot and the tooltips so that wow will run them with out of date addons disabled. 

This PR does not fix the localization sub-addons. 